### PR TITLE
EraseGlobalDeclare

### DIFF
--- a/src/cytanb_annotations.lua
+++ b/src/cytanb_annotations.lua
@@ -7,7 +7,7 @@
 
 ---@alias cytanb_uuid_t number[]
 
----@class cytanb @UUID、ログ、色、メッセージなど、基礎的な機能を提供するモジュール。
+---@class cytanb UUID、ログ、色、メッセージなど、基礎的な機能を提供するモジュール。
 ---@field FatalLogLevel number @致命的なレベルのログを表す定数値。
 ---@field ErrorLogLevel number @エラーレベルのログを表す定数値。
 ---@field WarnLogLevel number @警告レベルのログを表す定数値。
@@ -47,4 +47,3 @@
 ---@field TableFromSerializable fun (serData: table): table @TableToSerializable で変換したテーブルを復元する。
 ---@field EmitMessage fun (name: string, parameterMap: table<string, any>) @パラメーターを JSON シリアライズして `vci.message.Emit` する。`name` はメッセージ名を指定する。`parameterMap` は送信するパラメーターのテーブルを指定する(省略可能)。また、`InstanceID` がパラメーターフィールド `__CYTANB_INSTANCE_ID` として付加されて送信される。
 ---@field OnMessage fun (name: string, callback: fun(sender: table, name: string, parameterMap: table)) @`EmitMessage` したメッセージを受信するコールバック関数を登録する。`name` はメッセージ名を指定する。`callback` 関数に渡される `parameterMap` は JSON データをデシリアライズしたテーブル。また、パラメーターフィールド `__CYTANB_INSTANCE_ID` を利用してメッセージ送信元のインスタンスを識別可能。もしデシリアライズできないデータであった場合は、パラメーターフィールド `__CYTANB_MESSAGE_VALUE` に値がセットされる。
-cytanb = {}


### PR DESCRIPTION
変数の宣言をしなくても、アノテーションは機能します。
グローバル変数というわけではないことを加味すると、必要ないのではと考えました。